### PR TITLE
python 3 compatibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,3 @@
-Eaze Fork
-=======
-
-The version of Keytree on PyPi has some minor syntax errors that make it incompatible with Python 3. This fork is a (hopefully temporary) workaround so that we can use it. Ideally we'll want to contribute these changes back into the main Keytree codebase.
-
 Keytree
 =======
 

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,8 @@
+Eaze Fork
+=======
+
+The version of Keytree on PyPi has some minor syntax errors that make it incompatible with Python 3. This fork is a (hopefully temporary) workaround so that we can use it. Ideally we'll want to contribute these changes back into the main Keytree codebase.
+
 Keytree
 =======
 

--- a/keytree/__init__.py
+++ b/keytree/__init__.py
@@ -1,3 +1,3 @@
 #
-from factory import feature, geometry
-from kml import element
+from keytree.factory import feature, geometry
+from keytree.kml import element

--- a/keytree/kml.py
+++ b/keytree/kml.py
@@ -89,7 +89,7 @@ def coords_to_kml(geom):
     elif len(coords[0]) == 3:
         tuples = ('%f,%f,%f' % tuple(c) for c in coords)
     else:
-        raise ValueError, "Invalid dimensions"
+        raise ValueError("Invalid dimensions")
     return ' '.join(tuples)
 
 def geometry_element(context, ns, ob):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 import sys, os
 
-version = '0.2.1'
+version = '0.3.0'
 try:
     desc = open('README.rst', 'r').read()
 except:


### PR DESCRIPTION
Couple of syntax fixes so that this package supports Python 3.

Versioned to 0.3.0 but I could also see just doing a 0.0.1 bump. I'll leave that up to the authors.