### PR TITLE
Convert tests to pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: python
 python:
   - "3.7"
 install:
-  - "pip install pytest"
+  - "pip install pytest lxml"
   - "python setup.py develop"
 script:
   - "pytest"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
 dist: xenial
 language: python
 python:
-  - "2.7"
   - "3.7"
 install:
-  - "pip install nose"
+  - "pip install pytest"
   - "python setup.py develop"
 script:
-  - "python setup.py test"
+  - "pytest"
 deploy:
   on:
     repo: Toblerity/keytree

--- a/keytree/tests/conftest.py
+++ b/keytree/tests/conftest.py
@@ -6,7 +6,7 @@ from xml.etree import ElementTree
 @pytest.fixture(params=["lxml", "ElementTree"])
 def etree(request):
     if request.param == "lxml":
-        etree = pytest.importorskip("lxml")
+        etree = pytest.importorskip("lxml.etree")
     else:
         etree = ElementTree
     return etree

--- a/keytree/tests/conftest.py
+++ b/keytree/tests/conftest.py
@@ -1,9 +1,12 @@
-import xml.etree.ElementTree
-import lxml.etree
-
 import pytest
 
+from xml.etree import ElementTree
 
-@pytest.fixture(params=[lxml.etree, xml.etree.ElementTree])
+
+@pytest.fixture(params=["lxml", "ElementTree"])
 def etree(request):
-    return request.param
+    if request.param == "lxml":
+        etree = pytest.importorskip("lxml")
+    else:
+        etree = ElementTree
+    return etree

--- a/keytree/tests/conftest.py
+++ b/keytree/tests/conftest.py
@@ -1,0 +1,9 @@
+import xml.etree.ElementTree
+import lxml.etree
+
+import pytest
+
+
+@pytest.fixture(params=[lxml.etree, xml.etree.ElementTree])
+def etree(request):
+    return request.param

--- a/keytree/tests/test_read.py
+++ b/keytree/tests/test_read.py
@@ -2,7 +2,7 @@ import pytest
 
 from keytree import feature
 
-KML = b"""<?xml version="1.0" encoding="UTF-8"?>
+KML = """<?xml version="1.0" encoding="UTF-8"?>
 <kml xmlns="http://www.opengis.net/kml/2.2">
   <Document>
     <Placemark>
@@ -56,7 +56,7 @@ KML = b"""<?xml version="1.0" encoding="UTF-8"?>
     </Placemark>
   </Document>
 </kml>
-"""
+""".encode()  # lxml doesn't like unencoded strings with an encoding declaration
 
 
 #         self.placemarks = self.doc.findall(

--- a/keytree/tests/test_read.py
+++ b/keytree/tests/test_read.py
@@ -1,9 +1,8 @@
-from unittest import TestCase
-from xml.etree import ElementTree as etree
+import pytest
 
 from keytree import feature
 
-KML = """<?xml version="1.0" encoding="UTF-8"?>
+KML = b"""<?xml version="1.0" encoding="UTF-8"?>
 <kml xmlns="http://www.opengis.net/kml/2.2">
   <Document>
     <Placemark>
@@ -60,67 +59,74 @@ KML = """<?xml version="1.0" encoding="UTF-8"?>
 """
 
 
-class FeatureReaderTestCase(TestCase):
-    def setUp(self):
-        self.doc = etree.fromstring(KML)
-        self.placemarks = self.doc.findall(
-            "*/{http://www.opengis.net/kml/2.2}Placemark"
-        )
+#         self.placemarks = self.doc.findall(
+#             "*/{http://www.opengis.net/kml/2.2}Placemark"
+#         )
 
-    def failUnlessCoordsAlmostEqual(self, a, b, precision=7):
-        for x, y in zip(a, b):
-            self.assertAlmostEqual(x, y, precision)
 
-    def test_properties_context(self):
-        f = feature(self.placemarks[0])
-        props = f.properties
-        self.assertTrue("name" in props["@context"])
-        self.assertTrue("snippet" in props["@context"])
-        self.assertTrue("description" in props["@context"])
+@pytest.fixture
+def doc(etree):
+    return etree.fromstring(KML)
 
-    def test_point(self):
-        f = feature(self.placemarks[0])
-        self.assertTrue(f.geometry.type == f["geometry"]["type"] == "Point")
-        coords = f.geometry.coordinates
-        self.failUnlessCoordsAlmostEqual(coords, (-122.36438, 37.82466, 0.0), 5)
-        self.assertTrue(f.properties["name"] == f["properties"]["name"] == "point")
-        self.assertTrue(
-            f.properties["snippet"] == f["properties"]["snippet"] == "Point test"
-        )
-        self.assertTrue(
-            f.properties["description"]
-            == f["properties"]["description"]
-            == "Blah, blah, blah"
-        )
 
-    def test_linestring(self):
-        f = feature(self.placemarks[1])
-        self.assertTrue(f.geometry.type == f["geometry"]["type"] == "LineString")
-        coords0 = f.geometry.coordinates[0]
-        self.failUnlessCoordsAlmostEqual(coords0, (-122.36438, 37.82466, 0.0), 5)
-        self.assertTrue(f.properties["name"] == f["properties"]["name"] == "linestring")
-        self.assertTrue(
-            f.properties["snippet"] == f["properties"]["snippet"] == "LineString test"
-        )
-        self.assertTrue(
-            f.properties["description"]
-            == f["properties"]["description"]
-            == "Blah, blah, blah"
-        )
+@pytest.fixture
+def placemarks(doc):
+    return doc.findall(
+        ".//kml:Placemark",
+        namespaces={
+            "": "http://www.opengis.net/kml/2.2",
+            "kml": "http://www.opengis.net/kml/2.2",
+        },
+    )
 
-    def test_polygon(self):
-        f = feature(self.placemarks[2])
-        self.assertTrue(f.geometry.type == f["geometry"]["type"] == "Polygon")
-        coords0 = f.geometry.coordinates[0][0]
-        self.failUnlessCoordsAlmostEqual(coords0, (-122.366278, 37.81884, 30.0), 5)
-        self.assertTrue(f.properties["name"] == f["properties"]["name"] == "polygon")
-        self.assertTrue(
-            f.properties["snippet"] == f["properties"]["snippet"] == "Polygon test"
-        )
-        self.assertTrue(
-            f.properties["description"]
-            == f["properties"]["description"]
-            == "Blah, blah, blah"
-        )
-        coords1 = f.geometry.coordinates[1][0]
-        self.failUnlessCoordsAlmostEqual(coords1, (-122.366212, 37.818977, 30.0), 5)
+
+def test_properties_context(placemarks):
+    f = feature(placemarks[0])
+    props = f.properties
+    assert "name" in props["@context"]
+    assert "snippet" in props["@context"]
+    assert "description" in props["@context"]
+
+
+def test_point(placemarks):
+    f = feature(placemarks[0])
+    assert f.geometry.type == f["geometry"]["type"] == "Point"
+    coords = f.geometry.coordinates
+    assert coords == pytest.approx((-122.36438, 37.82466, 0.0), 5)
+    assert f.properties["name"] == f["properties"]["name"] == "point"
+    assert f.properties["snippet"] == f["properties"]["snippet"] == "Point test"
+    assert (
+        f.properties["description"]
+        == f["properties"]["description"]
+        == "Blah, blah, blah"
+    )
+
+
+def test_linestring(placemarks):
+    f = feature(placemarks[1])
+    assert f.geometry.type == f["geometry"]["type"] == "LineString"
+    coords0 = f.geometry.coordinates[0]
+    assert coords0 == pytest.approx((-122.36438, 37.82466, 0.0), 5)
+    assert f.properties["name"] == f["properties"]["name"] == "linestring"
+    assert f.properties["snippet"] == f["properties"]["snippet"] == "LineString test"
+    assert (
+        f.properties["description"]
+        == f["properties"]["description"]
+        == "Blah, blah, blah"
+    )
+
+
+def test_polygon(placemarks):
+    f = feature(placemarks[2])
+    assert f.geometry.type == f["geometry"]["type"] == "Polygon"
+    coords0 = f.geometry.coordinates[0][0]
+    assert coords0 == pytest.approx((-122.366278, 37.81884, 30.0), 5)
+    assert f.properties["name"] == f["properties"]["name"] == "polygon"
+    assert f.properties["snippet"] == f["properties"]["snippet"] == "Polygon test"
+    assert (
+        f.properties["description"]
+        == f["properties"]["description"]
+        == "Blah, blah, blah"
+    )
+    coords1 = f.geometry.coordinates[1][0]
+    assert coords1 == pytest.approx((-122.366212, 37.818977, 30.0), 5)

--- a/keytree/tests/test_write.py
+++ b/keytree/tests/test_write.py
@@ -1,9 +1,8 @@
-from unittest import TestCase
-from xml.etree import ElementTree as etree
+import pytest
 
 from keytree import element
 
-KML = """<?xml version="1.0" encoding="UTF-8"?>
+KML = b"""<?xml version="1.0" encoding="UTF-8"?>
 <kml xmlns="http://www.opengis.net/kml/2.2">
   <Document>
   </Document>
@@ -11,40 +10,39 @@ KML = """<?xml version="1.0" encoding="UTF-8"?>
 """
 
 
-class ElementWriterTestCase(TestCase):
-    def setUp(self):
-        self.doc = etree.fromstring(KML)
+@pytest.fixture
+def doc(etree):
+    return etree.fromstring(KML)
 
-    def test_element(self):
-        f = {
-            "id": "1",
-            "geometry": {"type": "Point", "coordinates": (0.0, 0.0)},
-            "properties": {"title": "one", "description": "Point one"},
-        }
-        elem = element(self.doc, f)
-        self.assertEqual(elem.tag, "{http://www.opengis.net/kml/2.2}Placemark")
-        self.assertEqual(elem.attrib["id"], "1")
-        self.assertEqual(elem.find("{http://www.opengis.net/kml/2.2}name").text, "one")
-        self.assertEqual(
-            elem.find("{http://www.opengis.net/kml/2.2}Snippet").text, "Point one"
-        )
-        self.assertEqual(
-            elem.find("{http://www.opengis.net/kml/2.2}Point")
-            .find("{http://www.opengis.net/kml/2.2}coordinates")
-            .text,
-            "0.000000,0.000000,0.0",
-        )
 
-    def test_element_kw(self):
-        f = {
-            "id": "1",
-            "geometry": {"type": "Point", "coordinates": (0.0, 0.0)},
-            "properties": {},
-        }
-        elem = element(self.doc, f, name="one", snippet="Point one")
-        self.assertEqual(elem.tag, "{http://www.opengis.net/kml/2.2}Placemark")
-        self.assertEqual(elem.attrib["id"], "1")
-        self.assertEqual(elem.find("{http://www.opengis.net/kml/2.2}name").text, "one")
-        self.assertEqual(
-            elem.find("{http://www.opengis.net/kml/2.2}Snippet").text, "Point one"
-        )
+def test_element(doc):
+    f = {
+        "id": "1",
+        "geometry": {"type": "Point", "coordinates": (0.0, 0.0)},
+        "properties": {"title": "one", "description": "Point one"},
+    }
+    elem = element(doc, f)
+    assert elem.tag == "{http://www.opengis.net/kml/2.2}Placemark"
+    assert elem.attrib["id"] == "1"
+    assert elem.find("{http://www.opengis.net/kml/2.2}name").text == "one"
+    assert elem.find("{http://www.opengis.net/kml/2.2}Snippet").text == "Point one"
+
+    assert (
+        elem.find("{http://www.opengis.net/kml/2.2}Point")
+        .find("{http://www.opengis.net/kml/2.2}coordinates")
+        .text
+        == "0.000000,0.000000,0.0",
+    )
+
+
+def test_element_kw(doc):
+    f = {
+        "id": "1",
+        "geometry": {"type": "Point", "coordinates": (0.0, 0.0)},
+        "properties": {},
+    }
+    elem = element(doc, f, name="one", snippet="Point one")
+    assert elem.tag == "{http://www.opengis.net/kml/2.2}Placemark"
+    assert elem.attrib["id"] == "1"
+    assert elem.find("{http://www.opengis.net/kml/2.2}name").text == "one"
+    assert elem.find("{http://www.opengis.net/kml/2.2}Snippet").text == "Point one"

--- a/keytree/tests/test_write.py
+++ b/keytree/tests/test_write.py
@@ -2,12 +2,12 @@ import pytest
 
 from keytree import element
 
-KML = b"""<?xml version="1.0" encoding="UTF-8"?>
+KML = """<?xml version="1.0" encoding="UTF-8"?>
 <kml xmlns="http://www.opengis.net/kml/2.2">
   <Document>
   </Document>
 </kml>
-"""
+""".encode()  # lxml doesn't like unencoded strings with an encoding declaration
 
 
 @pytest.fixture

--- a/keytree/tests/test_write.py
+++ b/keytree/tests/test_write.py
@@ -31,7 +31,7 @@ def test_element(doc):
         elem.find("{http://www.opengis.net/kml/2.2}Point")
         .find("{http://www.opengis.net/kml/2.2}coordinates")
         .text
-        == "0.000000,0.000000,0.0",
+        == "0.000000,0.000000,0.0"
     )
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
-[nosetests]
+[tool:pytest]
 

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,6 @@ setup(
     license="BSD",
     packages=find_packages(exclude=["ez_setup", "examples", "tests"]),
     include_package_data=True,
-    tests_require="pytest",
+    tests_require=["pytest", "lxml"],
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,6 @@ setup(
     license="BSD",
     packages=find_packages(exclude=["ez_setup", "examples", "tests"]),
     include_package_data=True,
+    tests_require="pytest",
     zip_safe=False,
 )


### PR DESCRIPTION
While working on #6, I had been developing against `lxml` and had a nasty surprise when I tried to update the tests, which use `xml.etree`. To avoid this in the future, this PR changes the tests to use `pytest`, with its fixtures and parametrization, to test against both modules each time.